### PR TITLE
chore: remove redundant tsconfig options for TypeScript 6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "types": ["chrome", "vite/client"],
@@ -10,13 +9,11 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "esModuleInterop": true,
     "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "skipLibCheck": true
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- Remove `useDefineForClassFields`, `esModuleInterop`, and `forceConsistentCasingInFileNames` from `tsconfig.json` as they are now default in TypeScript 6
- These options were made redundant by TypeScript 6's new defaults, and keeping them adds unnecessary noise

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] `pnpm test` — all 8 tests pass
- [x] `pnpm build` — build succeeds
- [x] `pnpm lint` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)