### PR TITLE
chore: add .pnpm-store/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies
 /node_modules
+.pnpm-store/
 
 # lint
 .eslintcache


### PR DESCRIPTION
## Summary
- Add `.pnpm-store/` to `.gitignore` to prevent pnpm's content-addressable store from being committed

## Test plan
- [x] Verify `.pnpm-store/` is listed in `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)