### PR TITLE
chore: widen Renovate schedule to the whole first day of the month

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", "schedule:monthly"],
+  "extends": ["config:best-practices"],
+  "schedule": ["* * 1 * *"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
## Why

Updates kept piling up under **Awaiting Schedule** on the Dependency Dashboard.

The cause is the combination of two settings:

- `schedule:monthly` only allows Renovate to open PRs between 0:00 and 4:00 on the first day of the month.
- `prHourlyLimit: 2`, inherited from `config:best-practices`, caps PR creation at 2 per hour.

Together these cap PR creation at **8 per month**, which is fewer than the updates this repository accumulates, so the backlog never drained.

## What

Replace the `schedule:monthly` preset with an explicit `* * 1 * *` schedule. The monthly cadence is unchanged, but the window widens from 4 hours to the full 24 hours, raising the theoretical cap to 48 PRs per month.

```diff
-  "extends": ["config:best-practices", "schedule:monthly"],
+  "extends": ["config:best-practices"],
+  "schedule": ["* * 1 * *"],
```

`prHourlyLimit` is intentionally left untouched so the effect of the wider window can be observed on its own. If the backlog persists after the next run, adding `prHourlyLimit: 0` is the next step.

## Notes

- `prConcurrentLimit: 10` still applies. The `runtime dependencies (minor)` group is not automerged, so those PRs can occupy slots while awaiting review.
- This month's backlog will be cleared manually via the Dependency Dashboard checkboxes, which bypass the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)