### PR TITLE
chore: automerge Renovate updates to the packageManager field

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,12 @@
       "automerge": false
     },
     {
+      "description": "pnpm itself runs the CI install/lint/test/build path, so a green run is direct evidence that the version works",
+      "matchDepTypes": ["packageManager"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
       "description": "GitHub Actions updates stay in their own PR (no group) and automerge; a breakage surfaces immediately as a red CI run",
       "matchManagers": ["github-actions"],
       "automerge": true


### PR DESCRIPTION
## Why

Renovate opened #236 (`pnpm` 11.9.0 → 11.19.0) and left it awaiting manual review.

The cause is that `packageManager` is a **top-level field in `package.json`**, not an entry under `dependencies` or `devDependencies`. Renovate reports it as `depType: packageManager` under the `npm` manager, so none of the existing rules match it:

| Rule | Match condition | Matches? |
| --- | --- | --- |
| automergeable dependencies | `matchDepTypes: ["devDependencies"]` | No — different depType |
| automergeable dependencies | `matchDepTypes: ["dependencies"]` + patch | No — different depType |
| runtime dependencies (minor) | `matchDepTypes: ["dependencies"]` + minor | No — different depType |
| GitHub Actions | `matchManagers: ["github-actions"]` | No — manager is `npm` |
| digest/pin | `matchUpdateTypes: ["digest", "pin"]` | No — minor update |

With nothing matching, Renovate falls back to the default `automerge: false`.

## What

Add a rule matching `depType: packageManager`, limited to minor and patch updates.

```json
{
  "matchDepTypes": ["packageManager"],
  "matchUpdateTypes": ["minor", "patch"],
  "automerge": true
}
```

## Why minor and patch are safe to automerge

pnpm is what runs the install/lint/test/build path in CI, so a green run is direct evidence that the new version works in this repository — arguably stronger evidence than for a typical devDependency, since a broken version cannot produce a passing run.

This is the same reasoning already applied to the GitHub Actions rule: a breakage surfaces immediately as a red run rather than as a silent runtime defect. The `packageManager` version is also not part of the built extension, so it cannot affect what ships to users.

On #236 specifically, `check-and-test` passed and `renovate/stability-days` confirmed the minimum release age was met.

## Why major is excluded

A major pnpm release can change the lockfile format or default resolution settings. CI installs from scratch and never exercises an existing working copy, so a green run does not rule out breakage that only appears locally — for example a `pnpm-lock.yaml` that gets rewritten on the next install. Major updates stay manual.

## Note

Renovate evaluates its rules against all open PRs on each run, so #236 will be picked up and automerged once this is merged and the next Renovate job runs — no manual merge needed.

Note that #239 narrowed the schedule to `* * 1 * *`, so the next scheduled run is the first of next month. To apply this sooner, trigger a run from the Dependency Dashboard.
