### PR TITLE
fix(renovate): exclude pre-1.0.0 packages from automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,15 +6,26 @@
     "enabled": true,
     "automerge": true
   },
+  // Pre-1.0.0 packages are deliberately absent from every rule below.
+  // Renovate derives the update type from whichever version segment
+  // changed, so a 0.2.x to 0.3.x bump counts as minor even though SemVer
+  // lets any 0.x release break compatibility. Matching on the update type
+  // therefore says nothing about whether a 0.x update is safe. Excluding
+  // them via matchCurrentVersion leaves them matched by no rule, and the
+  // Renovate defaults take over: one PR per package, reviewed by hand.
   "packageRules": [
     {
-      "description": "Automerge group: devDependencies (any type) and production patch updates. Not shipped to production or covered by the type-checked build, so CI passing is enough to merge unattended",
+      // devDependencies of any update type, automerged.
+      // They never reach production, and the type-checked build exercises
+      // them, so a green CI run is enough to merge unattended.
       "matchDepTypes": ["devDependencies"],
       "groupName": "automergeable dependencies",
       "automerge": true
     },
     {
-      "description": "Production patch updates join the automerge group; patch releases are bug fixes only and the build acts as a smoke test",
+      // Production patch updates, automerged alongside the group above.
+      // From 1.0.0 onward a patch release carries bug fixes only, and the
+      // build acts as a smoke test.
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"],
       "matchCurrentVersion": "!/^0/",
@@ -22,7 +33,9 @@
       "automerge": true
     },
     {
-      "description": "Production minor updates are grouped separately for a single monthly manual review; not automerged until smoke tests cover rendering/runtime behavior",
+      // Production minor updates, held for one monthly manual review.
+      // A minor release may change runtime behavior that CI does not
+      // assert, so these stay manual until smoke tests cover it.
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": "!/^0/",
@@ -30,18 +43,24 @@
       "automerge": false
     },
     {
-      "description": "pnpm itself runs the CI install/lint/test/build path, so a green run is direct evidence that the version works",
+      // pnpm minor and patch updates, automerged in their own PR.
+      // pnpm itself runs the CI install/lint/test/build path, so a green
+      // run is direct evidence that the version works.
       "matchDepTypes": ["packageManager"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },
     {
-      "description": "GitHub Actions updates stay in their own PR (no group) and automerge; a breakage surfaces immediately as a red CI run",
+      // GitHub Actions updates, automerged in their own PR.
+      // A breakage surfaces immediately as a red CI run.
       "matchManagers": ["github-actions"],
       "automerge": true
     },
     {
-      "description": "Digest and pin updates automerge in their own PRs; pins are always split out by Renovate",
+      // Digest and pin updates, automerged in their own PRs.
+      // A pin only records the version already in use, and a digest
+      // re-resolves the same version tag, so neither is a version change
+      // a human could meaningfully review.
       "matchUpdateTypes": ["digest", "pin"],
       "automerge": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
       "description": "Production patch updates join the automerge group; patch releases are bug fixes only and the build acts as a smoke test",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "!/^0/",
       "groupName": "automergeable dependencies",
       "automerge": true
     },
@@ -24,6 +25,7 @@
       "description": "Production minor updates are grouped separately for a single monthly manual review; not automerged until smoke tests cover rendering/runtime behavior",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor"],
+      "matchCurrentVersion": "!/^0/",
       "groupName": "runtime dependencies (minor)",
       "automerge": false
     },


### PR DESCRIPTION
## Why

Renovate derives the update type from whichever version segment changed, so a `0.2.x` → `0.3.x` bump is classified as **minor** even though SemVer lets any `0.x` release break compatibility. Matching on the update type therefore says nothing about whether a `0.x` update is safe to merge unattended.

The maintainer states this explicitly in [renovatebot/renovate#15093](https://github.com/renovatebot/renovate/discussions/15093):

> You are misunderstanding the difference between a major update (eg 0.x to 1.x) and a breaking update (which 0.2.x to 0.3.x may be). 0.2.x to 0.3.x is a minor update, so current behaviour is correct.

Renovate's own [automerge docs](https://docs.renovatebot.com/key-concepts/automerge/) guard against this in their recommended example, noting that pre-1.0.0 packages "can make breaking changes at _any_ time according to the SemVer spec".

This repository currently declares no production `dependencies`, so no package is affected today. The change closes the gap in advance: without it, the first `0.x` production dependency added would be automerged on patch and grouped on minor purely because of how Renovate labels the update type.

## What

Add `"matchCurrentVersion": "!/^0/"` to the production patch and minor rules. This leaves `0.x` packages matched by no rule at all, so the Renovate defaults take over — `automerge: false` and `groupName: null`, i.e. one PR per package, reviewed by hand. PRs are still raised as before; only the automerge is withheld.

`devDependencies` are unchanged. That rule already automerges every update type including major, so singling out `0.x` there would not be consistent with the existing decision — which matters here, since `@crxjs/vite-plugin`, `@types/chrome` and `sass` are all pre-1.0.0.

The second commit replaces the per-rule `description` fields with JSONC comments. Renovate parses `.json` config as JSONC, so this needs no file rename. `description` exists to describe a config or preset — only the top-level one is rendered, in the onboarding PR summary — so using it per rule was a workaround for a file that could not hold comments. The `devDependencies` description was also inaccurate: it described the production patch rule as well.

## Behavior

| Package | Update | Before | After |
| --- | --- | --- | --- |
| production `0.x` (none today) | patch | automerged in group | own PR, manual |
| same | minor | grouped for monthly review | own PR, manual |
| production 1.0.0+ (none today) | patch / minor | unchanged | unchanged |
| devDependencies | any | unchanged | unchanged |

## Verification

- `renovate-config-validator` passes.
- `prettier --check renovate.json` passes — the JSONC comments need no formatter configuration.
- Parsed the committed file with Renovate 44.33.2's `parseJson` and diffed against the pre-comment config: the removed `description` fields are the only difference, with all 6 rules otherwise identical.
- Checked `getRegexPredicate('!/^0/')` against real versions in this repo: `false` for `0.2.2` / `0.35.0`, `true` for `1.0.0` / `2.7.1` / `8.2.0` / `17.14.1`.
- `matchCurrentVersion` compares against the lockfile-resolved version rather than the range string, so caret ranges are not an issue.

Applies the same change as hamakou108/my-blog#85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)